### PR TITLE
Feat/follow

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": ["i18n/**/*"],
+    "watchAssets": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,21 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
-        "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/platform-express": "^11.1.5",
+        "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.12.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "fs-extra": "^11.3.0",
+        "i18n": "^0.15.1",
+        "nestjs-i18n": "^10.5.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "slugify": "^1.6.6",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -1932,6 +1938,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/@messageformat/core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-NgCFubFFIdMWJGN5WuQhHCNmzk7QgiVfrViFxcS99j7F5dDS5EP6raR54I+2ydhe4+5/XTn/YIEppFaqqVWHsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@messageformat/date-skeleton": "^1.0.0",
+        "@messageformat/number-skeleton": "^1.0.0",
+        "@messageformat/parser": "^5.1.0",
+        "@messageformat/runtime": "^3.0.1",
+        "make-plural": "^7.0.0",
+        "safe-identifier": "^0.4.1"
+      }
+    },
+    "node_modules/@messageformat/date-skeleton": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/date-skeleton/-/date-skeleton-1.1.0.tgz",
+      "integrity": "sha512-rmGAfB1tIPER+gh3p/RgA+PVeRE/gxuQ2w4snFWPF5xtb5mbWR7Cbw7wCOftcUypbD6HVoxrVdyyghPm3WzP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@messageformat/number-skeleton": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/number-skeleton/-/number-skeleton-1.2.0.tgz",
+      "integrity": "sha512-xsgwcL7J7WhlHJ3RNbaVgssaIwcEyFkBqxHdcdaiJzwTZAWEOD8BuUFxnxV9k5S0qHN3v/KzUpq0IUpjH1seRg==",
+      "license": "MIT"
+    },
+    "node_modules/@messageformat/parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
+      "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1"
+      }
+    },
+    "node_modules/@messageformat/runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@messageformat/runtime/-/runtime-3.0.1.tgz",
+      "integrity": "sha512-6RU5ol2lDtO8bD9Yxe6CZkl0DArdv0qkuoZC+ZwowU+cdRlVE1157wjCmlA5Rsf1Xc/brACnsZa5PZpEDfTFFg==",
+      "license": "MIT",
+      "dependencies": {
+        "make-plural": "^7.0.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.4.tgz",
@@ -2537,6 +2593,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
@@ -2548,14 +2624,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.4.tgz",
-      "integrity": "sha512-SDpfSDJogCZ3fOeP518+GdjKnpJc51LN0dylapq3xBfxJeiEOqmqiZM1tWMOsoijPlUVsz0acpmaVEaOiMXpXw==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.5.tgz",
+      "integrity": "sha512-OsoiUBY9Shs5IG3uvDIt9/IDfY5OlvWBESuB/K4Eun8xILw1EK5d5qMfC3d2sIJ+kA3l+kBR1d/RuzH7VprLIg==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
-        "multer": "2.0.1",
+        "multer": "2.0.2",
         "path-to-regexp": "8.2.0",
         "tslib": "2.8.1"
       },
@@ -2664,6 +2740,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2865,6 +2974,13 @@
       "dependencies": {
         "@prisma/debug": "6.12.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -4587,6 +4703,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/accept-language-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
+      "integrity": "sha512-QhyTbMLYo0BBGg1aWbeMG4ekWtds/31BrEU+DONOg/7ax23vxpL03Pb7/zBmha2v7vdD3AyzZVWBVGEZxKOXWw==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4788,7 +4910,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4802,7 +4923,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4849,7 +4969,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -5061,6 +5180,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/binary-version": {
@@ -5276,7 +5407,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -6823,6 +6953,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-printf": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.10.tgz",
+      "integrity": "sha512-GwTgG9O4FVIdShhbVF3JxOgSBY2+ePGsu2V/UONgoCPzF9VY6ZdBMKsHKCYQHZwNk3qNouUolRDsgVxcVA5G1w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -6969,7 +7108,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7095,6 +7233,21 @@
         "webpack": "^5.11.0"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -7182,10 +7335,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -7193,7 +7345,7 @@
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-monkey": {
@@ -7214,7 +7366,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7442,7 +7593,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -7573,6 +7723,26 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18n": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.15.1.tgz",
+      "integrity": "sha512-yue187t8MqUPMHdKjiZGrX+L+xcUsDClGO0Cz4loaKUOK9WrGw5pgan4bv130utOwX7fHE9w2iUeHFalVQWkXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@messageformat/core": "^3.0.0",
+        "debug": "^4.3.3",
+        "fast-printf": "^1.6.9",
+        "make-plural": "^7.0.0",
+        "math-interval-parser": "^2.0.1",
+        "mustache": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mashpie"
       }
     },
     "node_modules/iconv-lite": {
@@ -7708,6 +7878,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -7728,7 +7910,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7758,7 +7939,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7781,7 +7961,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8643,7 +8822,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8717,7 +8895,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -8885,7 +9062,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -9017,6 +9193,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/make-plural": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.4.0.tgz",
+      "integrity": "sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg==",
+      "license": "Unicode-DFS-2016"
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -9025,6 +9207,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-interval-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
+      "integrity": "sha512-VmlAmb0UJwlvMyx8iPhXUDnVW1F9IrGEd9CIOmv+XL8AErCUUuozoDMrgImvnYt2A+53qVX/tPW6YJurMKYsvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -9225,6 +9416,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9232,9 +9429,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -9292,6 +9489,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -9324,6 +9530,89 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nestjs-i18n": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-10.5.1.tgz",
+      "integrity": "sha512-cJJFz+RUfav23QACpGCq1pdXNLYC3tBesrP14RGoE/YYcD4xosQPX2eyjvDNuo0Ti63Xtn6j57wDNEUKrZqmSw==",
+      "license": "MIT",
+      "dependencies": {
+        "accept-language-parser": "^1.5.0",
+        "chokidar": "^3.6.0",
+        "cookie": "^0.7.0",
+        "iterare": "^1.2.1",
+        "js-yaml": "^4.1.0",
+        "string-format": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "*",
+        "@nestjs/core": "*",
+        "class-validator": "*",
+        "rxjs": "*"
+      }
+    },
+    "node_modules/nestjs-i18n/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/nestjs-i18n/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/nestjs-i18n/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/nestjs-i18n/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -9380,7 +9669,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10398,6 +10686,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-identifier": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
+      "license": "ISC"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10666,6 +10960,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -10792,6 +11095,12 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+      "license": "WTFPL OR MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -11083,6 +11392,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {
@@ -11394,7 +11727,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -11769,7 +12101,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -24,15 +24,21 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
-    "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/platform-express": "^11.1.5",
+    "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.12.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "fs-extra": "^11.3.0",
+    "i18n": "^0.15.1",
+    "nestjs-i18n": "^10.5.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "slugify": "^1.6.6",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/prisma/migrations/20250721045957_add_article_model/migration.sql
+++ b/prisma/migrations/20250721045957_add_article_model/migration.sql
@@ -1,0 +1,49 @@
+/*
+  Warnings:
+
+  - Made the column `name` on table `user` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE `user` MODIFY `name` VARCHAR(191) NOT NULL;
+
+-- CreateTable
+CREATE TABLE `Article` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `slug` VARCHAR(191) NOT NULL,
+    `title` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NOT NULL,
+    `body` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `authorId` INTEGER NOT NULL,
+
+    UNIQUE INDEX `Article_slug_key`(`slug`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Tag` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+
+    UNIQUE INDEX `Tag_name_key`(`name`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ArticleTag` (
+    `articleId` INTEGER NOT NULL,
+    `tagId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`articleId`, `tagId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Article` ADD CONSTRAINT `Article_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ArticleTag` ADD CONSTRAINT `ArticleTag_articleId_fkey` FOREIGN KEY (`articleId`) REFERENCES `Article`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ArticleTag` ADD CONSTRAINT `ArticleTag_tagId_fkey` FOREIGN KEY (`tagId`) REFERENCES `Tag`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250721062403_add_article_model/migration.sql
+++ b/prisma/migrations/20250721062403_add_article_model/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `user` table. All the data in the column will be lost.
+  - You are about to drop the `articletag` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[username]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `username` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE `articletag` DROP FOREIGN KEY `ArticleTag_articleId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `articletag` DROP FOREIGN KEY `ArticleTag_tagId_fkey`;
+
+-- AlterTable
+ALTER TABLE `user` DROP COLUMN `name`,
+    ADD COLUMN `username` VARCHAR(191) NOT NULL;
+
+-- DropTable
+DROP TABLE `articletag`;
+
+-- CreateTable
+CREATE TABLE `_ArticleToTag` (
+    `A` INTEGER NOT NULL,
+    `B` INTEGER NOT NULL,
+
+    UNIQUE INDEX `_ArticleToTag_AB_unique`(`A`, `B`),
+    INDEX `_ArticleToTag_B_index`(`B`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `User_username_key` ON `User`(`username`);
+
+-- AddForeignKey
+ALTER TABLE `_ArticleToTag` ADD CONSTRAINT `_ArticleToTag_A_fkey` FOREIGN KEY (`A`) REFERENCES `Article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `_ArticleToTag` ADD CONSTRAINT `_ArticleToTag_B_fkey` FOREIGN KEY (`B`) REFERENCES `Tag`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250721072046_add_profile/migration.sql
+++ b/prisma/migrations/20250721072046_add_profile/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE `_UserFollows` (
+    `A` INTEGER NOT NULL,
+    `B` INTEGER NOT NULL,
+
+    UNIQUE INDEX `_UserFollows_AB_unique`(`A`, `B`),
+    INDEX `_UserFollows_B_index`(`B`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `_FavoritedArticles` (
+    `A` INTEGER NOT NULL,
+    `B` INTEGER NOT NULL,
+
+    UNIQUE INDEX `_FavoritedArticles_AB_unique`(`A`, `B`),
+    INDEX `_FavoritedArticles_B_index`(`B`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `_UserFollows` ADD CONSTRAINT `_UserFollows_A_fkey` FOREIGN KEY (`A`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `_UserFollows` ADD CONSTRAINT `_UserFollows_B_fkey` FOREIGN KEY (`B`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `_FavoritedArticles` ADD CONSTRAINT `_FavoritedArticles_A_fkey` FOREIGN KEY (`A`) REFERENCES `Article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `_FavoritedArticles` ADD CONSTRAINT `_FavoritedArticles_B_fkey` FOREIGN KEY (`B`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,10 +16,39 @@ datasource db {
 model User {
   id        Int   @id @default(autoincrement())
   email     String   @unique
-  name      String
+  username  String   @unique
   password  String
   bio       String?
   image     String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  articles  Article[]
+  favoritedArticles Article[] @relation("FavoritedArticles")
+
+  followers User[] @relation("UserFollows")
+  following User[] @relation("UserFollows")
+}
+
+model Article {
+  id          Int      @id @default(autoincrement())
+  slug        String   @unique
+  title       String
+  description String
+  body        String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+
+  tags      Tag[]
+  favoritedBy User[] @relation("FavoritedArticles")
+}
+
+model Tag {
+  id    Int    @id @default(autoincrement())
+  name  String @unique
+
+  articles Article[]
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,8 +5,17 @@ import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { PrismaModule } from '../prisma/prisma.module';
 
+import { ProfilesModule } from './profiles/profiles.module';
+import { I18nModule } from 'nestjs-i18n';
+import { i18nConfig } from './configs/i18n.config';
 @Module({
-  imports: [AuthModule, UserModule, PrismaModule],
+  imports: [
+    I18nModule.forRoot(i18nConfig),
+    AuthModule,
+    UserModule,
+    PrismaModule,
+    ProfilesModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/decorator/getUser.decorator.ts
+++ b/src/auth/decorator/getUser.decorator.ts
@@ -1,7 +1,11 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { User } from '@prisma/client';
 
 export const GetUser = createParamDecorator(
-  (data: string | undefined, ctx: ExecutionContext) => {
+  (
+    data: keyof User | undefined,
+    ctx: ExecutionContext,
+  ): User[keyof User] | User | null => {
     const request = ctx.switchToHttp().getRequest();
 
     if (!request.user) {

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -2,7 +2,7 @@ import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 
 export class RegisterDto {
   @IsNotEmpty()
-  name: string;
+  username: string;
 
   @IsEmail()
   email: string;

--- a/src/auth/guards/optional-auth.guard.ts
+++ b/src/auth/guards/optional-auth.guard.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class OptionalAuthGuard extends AuthGuard('jwt') {
+  handleRequest(user) {
+    return user;
+  }
+}

--- a/src/auth/interfaces/jwt-payload.interface.ts
+++ b/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,0 +1,4 @@
+export interface JwtPayload {
+  sub: number;
+  username: string;
+}

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PrismaService } from 'prisma/prisma.service';
+import { JwtPayload } from '../interfaces/jwt-payload.interface';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -13,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: { sub: number; username: string }) {
+  async validate(payload: JwtPayload) {
     const user = await this.prisma.user.findUnique({
       where: { id: payload.sub },
     });

--- a/src/configs/i18n.config.ts
+++ b/src/configs/i18n.config.ts
@@ -1,0 +1,17 @@
+import { I18nOptions } from 'nestjs-i18n';
+import * as path from 'path';
+import { AcceptLanguageResolver } from 'nestjs-i18n';
+
+export const i18nConfig: I18nOptions = {
+  fallbackLanguage: 'en',
+  loaderOptions: {
+    path: path.resolve(process.cwd(), 'src/i18n'),
+    watch: true,
+  },
+  resolvers: [
+    {
+      use: AcceptLanguageResolver,
+      options: ['lang'],
+    },
+  ],
+};

--- a/src/i18n/en/errors.json
+++ b/src/i18n/en/errors.json
@@ -1,0 +1,8 @@
+{
+  "profileNotFound": "Profile not found",
+  "userToFollowNotFound": "User to follow not found",
+  "userToUnfollowNotFound": "User to unfollow not found",
+  "cannotFollowSelf": "Cannot follow yourself",
+  "alreadyFollowing": "You are already following this user",
+  "notFollowing": "You are not following this user"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,29 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('MediumClone API')
+    .setDescription('The MediumClone API description')
+    .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'JWT',
+        description: 'Enter JWT token',
+        in: 'header',
+      },
+      'JWT-auth',
+    )
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/profiles/dto/profile-response.dto.ts
+++ b/src/profiles/dto/profile-response.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class ProfileDataDto {
+  @ApiProperty({ example: 'userB', description: 'Username of the profile' })
+  username: string;
+
+  @ApiProperty({
+    example: 'I like to write code.',
+    description: 'User biography',
+    nullable: true,
+  })
+  bio: string | null;
+
+  @ApiProperty({
+    example: 'https://api.realworld.io/images/smiley-cyrus.jpeg',
+    description: 'Link to user profile image',
+    nullable: true,
+  })
+  image: string | null;
+
+  @ApiProperty({
+    example: false,
+    description: 'True if the current user is following this profile',
+  })
+  following: boolean;
+}
+
+export class ProfileResponseDto {
+  @ApiProperty({ type: () => ProfileDataDto })
+  profile: ProfileDataDto;
+}

--- a/src/profiles/dto/profile.dto.ts
+++ b/src/profiles/dto/profile.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@prisma/client';
+
+export class ProfileDto {
+  @ApiProperty({ example: 'john_doe' })
+  username: string;
+
+  @ApiProperty({ example: 'I am a software engineer.' })
+  bio: string | null;
+
+  @ApiProperty({ example: 'https://example.com/avatar.jpg' })
+  image: string | null;
+
+  @ApiProperty({ example: true })
+  following: boolean;
+
+  constructor(user: User, following: boolean) {
+    this.username = user.username;
+    this.bio = user.bio;
+    this.image = user.image;
+    this.following = following;
+  }
+}
+
+export class ProfileResponseDto {
+  @ApiProperty()
+  profile: ProfileDto;
+
+  constructor(profile: ProfileDto) {
+    this.profile = profile;
+  }
+}

--- a/src/profiles/profiles.controller.spec.ts
+++ b/src/profiles/profiles.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProfilesController } from './profiles.controller';
+
+describe('ProfilesController', () => {
+  let controller: ProfilesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProfilesController],
+    }).compile();
+
+    controller = module.get<ProfilesController>(ProfilesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ProfilesService } from './profiles.service';
+import { GetUser } from 'src/auth/decorator/getUser.decorator';
+import { OptionalAuthGuard } from 'src/auth/guards/optional-auth.guard';
+import { User } from '@prisma/client';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('api/profiles')
+export class ProfilesController {
+  constructor(private readonly profilesService: ProfilesService) {}
+
+  @UseGuards(OptionalAuthGuard)
+  @Get(':username')
+  getProfile(
+    @Param('username') username: string,
+    @GetUser() currentUser?: User,
+  ) {
+    return this.profilesService.getProfile(username, currentUser);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Post(':username/follow')
+  followUser(
+    @GetUser() currentUser: User,
+    @Param('username') username: string,
+  ) {
+    return this.profilesService.followUser(currentUser, username);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Delete(':username/follow')
+  unfollowUser(
+    @GetUser() currentUser: User,
+    @Param('username') username: string,
+  ) {
+    return this.profilesService.unfollowUser(currentUser, username);
+  }
+}

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -5,7 +5,6 @@ import {
   Delete,
   Param,
   UseGuards,
-  HttpCode,
   HttpStatus,
 } from '@nestjs/common';
 import { ProfilesService } from './profiles.service';
@@ -13,35 +12,80 @@ import { GetUser } from 'src/auth/decorator/getUser.decorator';
 import { OptionalAuthGuard } from 'src/auth/guards/optional-auth.guard';
 import { User } from '@prisma/client';
 import { AuthGuard } from '@nestjs/passport';
+import { I18n, I18nContext } from 'nestjs-i18n';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { ProfileResponseDto } from './dto/profile-response.dto';
 
+@ApiTags('Profiles')
 @Controller('api/profiles')
 export class ProfilesController {
   constructor(private readonly profilesService: ProfilesService) {}
 
   @UseGuards(OptionalAuthGuard)
   @Get(':username')
-  getProfile(
+  @ApiOperation({ summary: 'Get a profile by username' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'The profile has been successfully returned.',
+    type: ProfileResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Profile not found.',
+  })
+  @ApiBearerAuth('JWT-auth')
+  async getProfile(
     @Param('username') username: string,
+    @I18n() i18n: I18nContext,
     @GetUser() currentUser?: User,
-  ) {
-    return this.profilesService.getProfile(username, currentUser);
+  ): Promise<ProfileResponseDto> {
+    return this.profilesService.getProfile(username, i18n, currentUser);
   }
 
   @UseGuards(AuthGuard('jwt'))
   @Post(':username/follow')
-  followUser(
+  @ApiOperation({ summary: 'Follow a user' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully followed the user.',
+    type: ProfileResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized.',
+  })
+  @ApiBearerAuth('JWT-auth')
+  async followUser(
     @GetUser() currentUser: User,
     @Param('username') username: string,
-  ) {
-    return this.profilesService.followUser(currentUser, username);
+    @I18n() i18n: I18nContext,
+  ): Promise<ProfileResponseDto> {
+    return this.profilesService.followUser(currentUser, username, i18n);
   }
 
   @UseGuards(AuthGuard('jwt'))
   @Delete(':username/follow')
-  unfollowUser(
+  @ApiOperation({ summary: 'Unfollow a user' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully unfollowed the user.',
+    type: ProfileResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized.',
+  })
+  @ApiBearerAuth('JWT-auth')
+  async unfollowUser(
     @GetUser() currentUser: User,
     @Param('username') username: string,
-  ) {
-    return this.profilesService.unfollowUser(currentUser, username);
+    @I18n() i18n: I18nContext,
+  ): Promise<ProfileResponseDto> {
+    return this.profilesService.unfollowUser(currentUser, username, i18n);
   }
 }

--- a/src/profiles/profiles.module.ts
+++ b/src/profiles/profiles.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ProfilesController } from './profiles.controller';
+import { ProfilesService } from './profiles.service';
+import { AuthModule } from 'src/auth/auth.module';
+import { PrismaModule } from 'prisma/prisma.module';
+
+@Module({
+  imports: [AuthModule, PrismaModule],
+  controllers: [ProfilesController],
+  providers: [ProfilesService],
+})
+export class ProfilesModule {}

--- a/src/profiles/profiles.module.ts
+++ b/src/profiles/profiles.module.ts
@@ -3,6 +3,7 @@ import { ProfilesController } from './profiles.controller';
 import { ProfilesService } from './profiles.service';
 import { AuthModule } from 'src/auth/auth.module';
 import { PrismaModule } from 'prisma/prisma.module';
+import { I18nModule } from 'nestjs-i18n';
 
 @Module({
   imports: [AuthModule, PrismaModule],

--- a/src/profiles/profiles.service.spec.ts
+++ b/src/profiles/profiles.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProfilesService } from './profiles.service';
+
+describe('ProfilesService', () => {
+  let service: ProfilesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProfilesService],
+    }).compile();
+
+    service = module.get<ProfilesService>(ProfilesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+import { User } from '@prisma/client';
+
+@Injectable()
+export class ProfilesService {
+  constructor(private prisma: PrismaService) {}
+
+  async getProfile(username: string, currentUser?: User) {
+    const userToFind = await this.prisma.user.findUnique({
+      where: { username },
+    });
+
+    if (!userToFind) {
+      throw new NotFoundException('Profile not found');
+    }
+
+    let following = false;
+    // Nếu có người dùng đang đăng nhập, kiểm tra xem họ có follow profile này không
+    if (currentUser) {
+      const followRelation = await this.prisma.user.findFirst({
+        where: {
+          id: currentUser.id,
+          following: {
+            some: {
+              id: userToFind.id,
+            },
+          },
+        },
+      });
+      if (followRelation) {
+        following = true;
+      }
+    }
+
+    return this.buildProfileResponse(userToFind, following);
+  }
+
+  async followUser(currentUser: User, usernameToFollow: string) {
+    if (currentUser.username === usernameToFollow) {
+      throw new NotFoundException('Cannot follow yourself');
+    }
+
+    const userToFollow = await this.prisma.user.findUnique({
+      where: { username: usernameToFollow },
+    });
+
+    if (!userToFollow) {
+      throw new NotFoundException('User to follow not found');
+    }
+
+    await this.prisma.user.update({
+      where: { id: currentUser.id },
+      data: {
+        following: {
+          connect: {
+            id: userToFollow.id,
+          },
+        },
+      },
+    });
+
+    return this.buildProfileResponse(userToFollow, true);
+  }
+
+  async unfollowUser(currentUser: User, usernameToUnfollow: string) {
+    const userToUnfollow = await this.prisma.user.findUnique({
+      where: { username: usernameToUnfollow },
+    });
+
+    if (!userToUnfollow) {
+      throw new NotFoundException('User to unfollow not found');
+    }
+
+    await this.prisma.user.update({
+      where: { id: currentUser.id },
+      data: {
+        following: {
+          disconnect: {
+            id: userToUnfollow.id,
+          },
+        },
+      },
+    });
+
+    return this.buildProfileResponse(userToUnfollow, false);
+  }
+
+  private buildProfileResponse(profile: User, following: boolean) {
+    return {
+      profile: {
+        username: profile.username,
+        bio: profile.bio,
+        image: profile.image,
+        following,
+      },
+    };
+  }
+}

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
 import { User } from '@prisma/client';
 
@@ -16,9 +20,8 @@ export class ProfilesService {
     }
 
     let following = false;
-    // Nếu có người dùng đang đăng nhập, kiểm tra xem họ có follow profile này không
     if (currentUser) {
-      const followRelation = await this.prisma.user.findFirst({
+      const followCount = await this.prisma.user.count({
         where: {
           id: currentUser.id,
           following: {
@@ -28,9 +31,7 @@ export class ProfilesService {
           },
         },
       });
-      if (followRelation) {
-        following = true;
-      }
+      following = followCount > 0;
     }
 
     return this.buildProfileResponse(userToFind, following);
@@ -38,7 +39,7 @@ export class ProfilesService {
 
   async followUser(currentUser: User, usernameToFollow: string) {
     if (currentUser.username === usernameToFollow) {
-      throw new NotFoundException('Cannot follow yourself');
+      throw new BadRequestException('Cannot follow yourself');
     }
 
     const userToFollow = await this.prisma.user.findUnique({
@@ -47,6 +48,17 @@ export class ProfilesService {
 
     if (!userToFollow) {
       throw new NotFoundException('User to follow not found');
+    }
+
+    const isAlreadyFollowing = await this.prisma.user.count({
+      where: {
+        id: currentUser.id,
+        following: { some: { id: userToFollow.id } },
+      },
+    });
+
+    if (isAlreadyFollowing) {
+      throw new BadRequestException('You are already following this user');
     }
 
     await this.prisma.user.update({
@@ -64,12 +76,27 @@ export class ProfilesService {
   }
 
   async unfollowUser(currentUser: User, usernameToUnfollow: string) {
+    if (currentUser.username === usernameToUnfollow) {
+      throw new BadRequestException('Cannot unfollow yourself');
+    }
+
     const userToUnfollow = await this.prisma.user.findUnique({
       where: { username: usernameToUnfollow },
     });
 
     if (!userToUnfollow) {
       throw new NotFoundException('User to unfollow not found');
+    }
+
+    const isFollowing = await this.prisma.user.count({
+      where: {
+        id: currentUser.id,
+        following: { some: { id: userToUnfollow.id } },
+      },
+    });
+
+    if (!isFollowing) {
+      throw new BadRequestException('You are not following this user');
     }
 
     await this.prisma.user.update({


### PR DESCRIPTION
# feat(profile): Thêm tính năng Profile và Follow

## Tóm tắt
Pull request này thêm các chức năng liên quan đến Profile người dùng, bao gồm xem thông tin, theo dõi và bỏ theo dõi.

## Các thay đổi chính
- Tạo `ProfilesModule`, `Controller`, và `Service` mới.
- Thêm các endpoint:
  - `GET /api/profiles/:username`: Lấy thông tin profile (xác thực không bắt buộc).
  - `POST /api/profiles/:username/follow`: Theo dõi một người dùng (yêu cầu xác thực).
  - `DELETE /api/profiles/:username/follow`: Bỏ theo dõi một người dùng (yêu cầu xác thực).
- Sử dụng `OptionalAuthGuard` cho endpoint lấy profile để xử lý cả khách và người dùng đã đăng nhập.

## Cách kiểm tra
1. Chuẩn bị 2 tài khoản: `userA` và `userB`.
2. Đăng nhập bằng `userA` để lấy token.
3. Dùng Postman để:
   - `GET` profile của `userB` (trường `following` sẽ là `false`).
   - `POST` để `userA` follow `userB` (trường `following` sẽ là `true`).
   - `DELETE` để `userA` bỏ follow `userB` (trường `following` sẽ là `false`).